### PR TITLE
Update guns in place with the ACE menu tool

### DIFF
--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -520,28 +520,99 @@ do
 		PhysObj:EnableCollisions( true )
 	end
 
-	-- Similar to constraint.RemoveAll, but leaves Entity.Constraints for the caller.
-	local function ClearConstraints( Constraints )
-		for _, Constraint in pairs( Constraints ) do
+	-- Wiremod hydraulics tie the constraint, its rope and its controller together with
+	-- DeleteOnRemove. Break those links first so removing the constraint doesn't take the
+	-- controller and rope down with it.
+	local function ClearHydraulic( Constraint )
+		local ID = Constraint.MyCrtl
+		if not ID then return end
+
+		local Controller = ents.GetByIndex( ID )
+		if not IsValid( Controller ) then return end
+
+		local Rope = Controller.Rope
+
+		Controller:DontDeleteOnRemove( Constraint )
+		Constraint:DontDeleteOnRemove( Controller )
+
+		if IsValid( Rope ) then
+			Controller:DontDeleteOnRemove( Rope )
+			Rope:DontDeleteOnRemove( Constraint )
+		end
+	end
+
+	-- Similar to constraint.RemoveAll.
+	local function ClearConstraints( Entity )
+		local Constraints = Entity.Constraints
+		if not Constraints then return end
+
+		for Index, Constraint in pairs( Constraints ) do
 			if IsValid( Constraint ) then
 				ResetCollisions( Constraint.Ent1 )
 				ResetCollisions( Constraint.Ent2 )
 
+				if Constraint.Type == "WireHydraulic" then
+					ClearHydraulic( Constraint )
+				end
+
 				Constraint:Remove()
 			end
+
+			Constraints[ Index ] = nil
 		end
+
+		Entity:IsConstrained()
+	end
+
+	local function GetFactory( Name )
+		if not Name then return end
+
+		return ConstraintTypes[ Name ]
+	end
+
+	-- Re-attach a rebuilt hydraulic constraint to its controller and rope, restoring the
+	-- controller's length and wire inputs.
+	local function RestoreHydraulic( ID, Constraint, Rope )
+		local Controller = ents.GetByIndex( ID )
+		if not IsValid( Controller ) then return end
+
+		Constraint.MyCrtl = Controller:EntIndex()
+		Controller.MyId   = Controller:EntIndex()
+
+		Controller:SetConstraint( Constraint )
+		Controller:DeleteOnRemove( Constraint )
+
+		if IsValid( Rope ) then
+			Controller:SetRope( Rope )
+			Controller:DeleteOnRemove( Rope )
+		end
+
+		Controller:SetLength( Controller.TargetLength )
+		Controller:TriggerInput( "Constant", Controller.current_constant )
+		Controller:TriggerInput( "Damping", Controller.current_damping )
+
+		Constraint:DeleteOnRemove( Controller )
 	end
 
 	local function RestoreConstraint( Data )
-		local Factory = ConstraintTypes[ Data.Type ]
+		local Type    = Data.Type
+		local Factory = GetFactory( Type )
 		if not Factory then return end
 
+		local ID   = Data.MyCrtl
 		local Args = {}
+
+		if ID then Data.MyCrtl = nil end
+
 		for Index, Name in ipairs( Factory.Args ) do
 			Args[ Index ] = Data[ Name ]
 		end
 
-		Factory.Func( unpack( Args ) )
+		local Constraint, Rope = Factory.Func( unpack( Args ) )
+
+		if Type == "WireHydraulic" then
+			RestoreHydraulic( ID, Constraint, Rope )
+		end
 	end
 
 	-- Snapshot an entity's constraints and physics state, then strip the
@@ -552,16 +623,15 @@ do
 		local PhysObj = Entity:GetPhysicsObject()
 		if not IsValid( PhysObj ) then return end
 
-		local Constraints = constraint.GetTable( Entity )
-
 		Saved[ Entity ] = {
-			Constraints = Constraints,
+			Constraints = constraint.GetTable( Entity ),
 			Gravity     = PhysObj:IsGravityEnabled(),
 			Motion      = PhysObj:IsMotionEnabled(),
+			Contents    = PhysObj:GetContents(),
 			Material    = PhysObj:GetMaterial(),
 		}
 
-		ClearConstraints( Constraints )
+		ClearConstraints( Entity )
 
 		-- If the entity dies before RestoreEntity runs, drop the snapshot.
 		Entity:CallOnRemove( "ACE_RestoreEntity", function()
@@ -580,6 +650,7 @@ do
 		if IsValid( PhysObj ) then
 			PhysObj:EnableGravity( Data.Gravity )
 			PhysObj:EnableMotion( Data.Motion )
+			PhysObj:SetContents( Data.Contents )
 			PhysObj:SetMaterial( Data.Material )
 		end
 

--- a/lua/acf/server/sv_acfbase.lua
+++ b/lua/acf/server/sv_acfbase.lua
@@ -497,6 +497,102 @@ function ACF_SquishyDamage(Entity, Energy, FrArea, _, Inflictor, Bone, Gun, Type
 end
 
 ----------------------------------------------------------
+-- Entity constraint/physics save & restore.
+--
+-- Some ACF components rebuild their physics object when updated in place
+-- (guns switching model, scalable crates, etc). Re-initialising physics drops
+-- every constraint attached to the old physics object, so a welded/roped gun
+-- would fall off its hull. Saving the constraints first and rebuilding them
+-- after keeps the contraption intact across the model swap.
+--
+-- Adapted from ACF-3's ACF.SaveEntity/RestoreEntity (lua/acf/core/utilities/util_sv.lua).
+----------------------------------------------------------
+do
+	local ConstraintTypes = duplicator.ConstraintType
+	local Saved = {}
+
+	local function ResetCollisions( Entity )
+		if not IsValid( Entity ) then return end
+
+		local PhysObj = Entity:GetPhysicsObject()
+		if not IsValid( PhysObj ) then return end
+
+		PhysObj:EnableCollisions( true )
+	end
+
+	-- Similar to constraint.RemoveAll, but leaves Entity.Constraints for the caller.
+	local function ClearConstraints( Constraints )
+		for _, Constraint in pairs( Constraints ) do
+			if IsValid( Constraint ) then
+				ResetCollisions( Constraint.Ent1 )
+				ResetCollisions( Constraint.Ent2 )
+
+				Constraint:Remove()
+			end
+		end
+	end
+
+	local function RestoreConstraint( Data )
+		local Factory = ConstraintTypes[ Data.Type ]
+		if not Factory then return end
+
+		local Args = {}
+		for Index, Name in ipairs( Factory.Args ) do
+			Args[ Index ] = Data[ Name ]
+		end
+
+		Factory.Func( unpack( Args ) )
+	end
+
+	-- Snapshot an entity's constraints and physics state, then strip the
+	-- constraints so a following PhysicsInit doesn't leave dangling welds.
+	function ACE.SaveEntity( Entity )
+		if not IsValid( Entity ) then return end
+
+		local PhysObj = Entity:GetPhysicsObject()
+		if not IsValid( PhysObj ) then return end
+
+		local Constraints = constraint.GetTable( Entity )
+
+		Saved[ Entity ] = {
+			Constraints = Constraints,
+			Gravity     = PhysObj:IsGravityEnabled(),
+			Motion      = PhysObj:IsMotionEnabled(),
+			Material    = PhysObj:GetMaterial(),
+		}
+
+		ClearConstraints( Constraints )
+
+		-- If the entity dies before RestoreEntity runs, drop the snapshot.
+		Entity:CallOnRemove( "ACE_RestoreEntity", function()
+			Saved[ Entity ] = nil
+		end )
+	end
+
+	-- Rebuild the constraints and physics state saved by ACE.SaveEntity.
+	function ACE.RestoreEntity( Entity )
+		if not IsValid( Entity ) then return end
+
+		local Data = Saved[ Entity ]
+		if not Data then return end
+
+		local PhysObj = Entity:GetPhysicsObject()
+		if IsValid( PhysObj ) then
+			PhysObj:EnableGravity( Data.Gravity )
+			PhysObj:EnableMotion( Data.Motion )
+			PhysObj:SetMaterial( Data.Material )
+		end
+
+		for _, Constraint in ipairs( Data.Constraints ) do
+			RestoreConstraint( Constraint )
+		end
+
+		Saved[ Entity ] = nil
+		Entity:RemoveCallOnRemove( "ACE_RestoreEntity" )
+	end
+end
+
+----------------------------------------------------------
 -- Returns a table of all physically connected entities
 -- ignoring ents attached by only nocollides
 ----------------------------------------------------------

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -347,7 +347,8 @@ do
 
 	-- Re-apply a gun in place when the ACF menu tool is used on an existing one, mirroring the
 	-- gearbox/engine/ammo behaviour. Clicking the same gun refreshes it without a respawn (wire
-	-- and ammo/crew links are kept); switching to another same-model gun swaps the stats over.
+	-- and ammo/crew links are kept); picking a different gun swaps the stats and, when needed, the
+	-- model over, keeping welds/parents intact so the gun stays mounted (see ACE.SaveEntity).
 	function ENT:Update( ArgsTable )
 		-- ArgsTable is the ACFCvars payload with the firing player, trace pos and angle prepended,
 		-- so the gun id lives at index 4 (matching the "id" entry registered above).
@@ -362,14 +363,12 @@ do
 			return false, "Invalid gun id!"
 		end
 
-		if Lookup.model ~= self.Model then
-			return false, "The new gun must use the same model!"
-		end
-
 		if self.Id ~= Id then
 			local ClassData = GunClasses[Lookup.gunclass]
+			local OldModel    = self.Model
 
 			self.Id           = Id
+			self.Model        = Lookup.model
 			self.Caliber      = Lookup.caliber
 			self.Mass         = Lookup.weight
 			self.Class        = Lookup.gunclass
@@ -424,9 +423,46 @@ do
 			self:SetNWString( "Sound", self.Sound )
 			self:SetNWInt( "SoundPitch", self.SoundPitch )
 
+			-- Switching gun id can also switch model (e.g. 100mm -> 120mm). Rebuild the model and
+			-- physics in place, preserving welds/parents so the gun stays on its mount, then refresh
+			-- the muzzle attachment and cached inertia the way a fresh spawn does. Mirrors ACF-3.
+			if self.Model ~= OldModel then
+				ACE.SaveEntity( self )
+
+				self:SetModel( self.Model )
+				self:PhysicsInit( SOLID_VPHYSICS )
+				self:SetMoveType( MOVETYPE_VPHYSICS )
+				self:SetSolid( SOLID_VPHYSICS )
+
+				ACE.RestoreEntity( self )
+
+				local Muzzle = self:GetAttachment( self:LookupAttachment( "muzzle" ) )
+				if Muzzle then self.Muzzle = self:WorldToLocal( Muzzle.Pos ) end
+
+				local longbarrel = ClassData.longbarrel
+				if longbarrel ~= nil then
+					timer.Simple( 0.25, function()
+						if not IsValid( self ) then return end
+						if self:GetBodygroup( longbarrel.index ) == longbarrel.submodel then
+							local LongMuzzle = self:GetAttachment( self:LookupAttachment( longbarrel.newpos ) )
+							if LongMuzzle then self.Muzzle = self:WorldToLocal( LongMuzzle.Pos ) end
+						end
+					end )
+				end
+			end
+
 			local phys = self:GetPhysicsObject()
 			if IsValid( phys ) then
 				phys:SetMass( self.Mass )
+				self.ModelInertia = 0.99 * phys:GetInertia() / phys:GetMass() -- giving a little wiggle room
+			end
+
+			-- The new model's hull may differ in size, so rebuild the ACF health/armor for it.
+			-- ACF_Activate caches ACF.Area, so clear it to force a recompute; Recalc keeps the
+			-- current damage as a percentage rather than resetting the gun to full health.
+			if self.Model ~= OldModel then
+				self.ACF.Area = nil
+				ACF_Activate( self, 1 )
 			end
 
 			-- Ammo crates are keyed to the old gun id, so any that no longer match are dropped

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -114,6 +114,7 @@ function ENT:Initialize()
 	self.LastThink           = 0
 
 	self.CanLegalCheck		= true
+	self.CanUpdate			= true		-- Lets the ACF menu tool re-apply this gun in place instead of respawning it
 
 	self:CallOnRemove("ACE_Points", function(ent)
 		if ACE.PointsInputChanged then ACE.PointsInputChanged(ent, "gun-removed") end
@@ -342,6 +343,117 @@ do
 
 		return Gun
 
+	end
+
+	-- Re-apply a gun in place when the ACF menu tool is used on an existing one, mirroring the
+	-- gearbox/engine/ammo behaviour. Clicking the same gun refreshes it without a respawn (wire
+	-- and ammo/crew links are kept); switching to another same-model gun swaps the stats over.
+	function ENT:Update( ArgsTable )
+		-- ArgsTable is the ACFCvars payload with the firing player, trace pos and angle prepended,
+		-- so the gun id lives at index 4 (matching the "id" entry registered above).
+		local Id = ArgsTable[4]
+
+		if not ACE.CheckGun( Id ) then
+			Id = BackComp[Id] or "100mmC"
+		end
+
+		local Lookup = GunTable[Id]
+		if not Lookup then
+			return false, "Invalid gun id!"
+		end
+
+		if Lookup.model ~= self.Model then
+			return false, "The new gun must use the same model!"
+		end
+
+		if self.Id ~= Id then
+			local ClassData = GunClasses[Lookup.gunclass]
+
+			self.Id           = Id
+			self.Caliber      = Lookup.caliber
+			self.Mass         = Lookup.weight
+			self.Class        = Lookup.gunclass
+			self.LinkRangeMul = math.max(Lookup.caliber / 10, 1) ^ 1.2
+			self.noloaders    = ClassData.noloader or nil
+			self.Inaccuracy   = ClassData.spread
+
+			self.RequiresGunner = false
+			local GunnerExcluded = Lookup.gunnerexception or false
+			if not GunnerExcluded and (self.Caliber * 10) > ACF.LargeGunsThreshold and ACF.LargeGunsRequireGunners ~= 0 then
+				self.RequiresGunner = true
+			end
+
+			if ClassData.color then
+				self:SetColor(Color(ClassData.color[1], ClassData.color[2], ClassData.color[3], 255))
+			end
+
+			self.PGRoFmod = Lookup.rofmod and math.max(0.01, Lookup.rofmod) or 1
+			self.maxrof   = Lookup.maxrof
+			self.MagSize  = 1
+
+			local Cal = self.Caliber
+			if Lookup.magsize then
+				self.MagSize = math.max(self.MagSize, Lookup.magsize)
+				self.Inputs  = WireLib.CreateInputs( self, Cal >= 3 and Inputs_Fuse or Inputs_NoFuse )
+			else
+				self.Inputs  = WireLib.CreateInputs( self, Cal >= 3 and Inputs_Fuse_noreload or Inputs_NoFuse_noreload )
+			end
+
+			self.Outputs = WireLib.CreateOutputs( self, Outputs_Default )
+			Wire_TriggerOutput(self, "Entity", self)
+
+			self.MagReload = 0
+			if Lookup.magreload then
+				self.MagReload = math.max(self.MagReload, Lookup.magreload)
+			end
+
+			self.MinLengthBonus = 0.5 * 3.1416 * (self.Caliber / 2) ^ 2 * Lookup.round.maxlength
+
+			self.Muzzleflash  = Lookup.muzzleflash or ClassData.muzzleflash
+			self.RoFmod       = ClassData.rofmod
+			self.Sound        = Lookup.sound or ClassData.sound
+			self.DefaultSound = self.Sound
+			self.SoundPitch   = 100
+			self.AutoSound    = ClassData.autosound and (Lookup.autosound or ClassData.autosound) or nil
+
+			self:SetNWInt( "Caliber", self.Caliber )
+			self:SetNWString( "WireName", Lookup.name )
+			self:SetNWString( "Class", self.Class )
+			self:SetNWString( "ID", self.Id )
+			self:SetNWString( "Muzzleflash", self.Muzzleflash )
+			self:SetNWString( "Sound", self.Sound )
+			self:SetNWInt( "SoundPitch", self.SoundPitch )
+
+			local phys = self:GetPhysicsObject()
+			if IsValid( phys ) then
+				phys:SetMass( self.Mass )
+			end
+
+			-- Ammo crates are keyed to the old gun id, so any that no longer match are dropped
+			-- rather than left silently feeding a mismatched gun.
+			local Dropped = 0
+			for _, Crate in ipairs( table.Copy( self.AmmoLink ) ) do
+				if IsValid( Crate ) and Crate.BulletData and Crate.BulletData.Id ~= self.Id then
+					self:Unlink( Crate )
+					if Crate.Unlink then Crate:Unlink( self ) end
+					Dropped = Dropped + 1
+				end
+			end
+
+			self:UpdateOverlayText()
+			RefreshGunRateOfFire(self)
+
+			if Dropped > 0 then
+				return true, "Gun updated. " .. Dropped .. " incompatible ammo crate(s) were unlinked."
+			end
+
+			return true, "Gun updated!"
+		end
+
+		self:UpdateOverlayText()
+		RefreshGunRateOfFire(self)
+
+		return true, "Gun refreshed!"
 	end
 end
 


### PR DESCRIPTION
**What does this PR do**: makes it possible now to alter the model for the guns by saving entity data and preserving its constraints and links. Previously you wouldn't be able to swap your 100mm C to 120mm C, now it is possible with this.

Was manually tested in Gmod, code was also reviewed. Logic taken straight from acf-3, basically what it does according to gmod wiki is reusing what gmod basic duplicator does by saving entity data. 
<img width="738" height="552" alt="image" src="https://github.com/user-attachments/assets/84b8b526-d394-4ddc-af41-61535fb92c3b" />


Co-authored by Opus 5