### PR TITLE
Cylindrical ammo model

### DIFF
--- a/lua/acf/client/cl_acemenu_gui.lua
+++ b/lua/acf/client/cl_acemenu_gui.lua
@@ -901,7 +901,9 @@ do
 			local Y = math.Round(acemenupanel.AmmoPanelConfig["Crate_Width"], 1 )
 			local Z = math.Round(acemenupanel.AmmoPanelConfig["Crate_Height"], 1)
 
+			local Shape = acemenupanel.AmmoPanelConfig["Crate_Shape"] or "Box"
 			local Id = X .. ":" .. Y .. ":" .. Z
+			if Shape ~= "Box" then Id = Id .. ":" .. Shape end
 
 			acemenupanel.AmmoData["Id"] = Id
 			RunConsoleCommand( "acemenu_id", Id )
@@ -937,6 +939,7 @@ do
 		acemenupanel.AmmoPanelConfig["Crate_Length"]  = 10
 		acemenupanel.AmmoPanelConfig["Crate_Width"]	= 10
 		acemenupanel.AmmoPanelConfig["Crate_Height"]  = 10
+		acemenupanel.AmmoPanelConfig["Crate_Shape"]   = "Box"
 
 	end
 
@@ -1030,6 +1033,24 @@ do
 			CreateIdForCrate( MainPanel )
 		end
 		CrateNewPanel:AddItem(HeightSlider)
+
+		acemenupanel:CPanelText("Crate_shape_desc", "\nCrate shape. Non-box shapes hold fewer rounds, matching the volume they fill.", nil, CrateNewPanel)
+
+		-- Keep this list in sync with the CrateShapes table in acf_ammo/init.lua.
+		local ShapeChoices = { "Box", "Cylinder" }
+
+		local ShapeCombo = vgui.Create( "DComboBox" )
+		ShapeCombo:SetSortItems( false )
+		for _, ShapeName in ipairs( ShapeChoices ) do
+			ShapeCombo:AddChoice( ShapeName )
+		end
+		ShapeCombo:SetValue( acemenupanel.AmmoPanelConfig["Crate_Shape"] or "Box" )
+
+		function ShapeCombo:OnSelect( _, value )
+			acemenupanel.AmmoPanelConfig["Crate_Shape"] = value
+			CreateIdForCrate( MainPanel )
+		end
+		CrateNewPanel:AddItem(ShapeCombo)
 
 	end
 

--- a/lua/acf/client/cl_acemenu_gui.lua
+++ b/lua/acf/client/cl_acemenu_gui.lua
@@ -1219,8 +1219,15 @@ function PANEL:AmmoSlider(Name, Value, Min, Max, Decimals, Title, Desc) --Variab
 	acemenupanel["CData"][Name].OnValueChanged = function( _, val )
 
 	--Programmatic SetMin/SetMax/SetValue (below) fire DNumSlider:ValueChanged, which calls
-	--this handler; skip re-entry during those so UpdateAttribs can't recurse into a stack overflow.
-	if acemenupanel["CData"][Name].ACEProgrammatic then return end
+	--this handler. Record the value so AmmoData tracks what the slider shows, but don't call
+	--UpdateAttribs from here or it recurses into a client stack overflow.
+	--Coupled sliders (propellant/projectile clamped against MaxTotalLength) rely on this write:
+	--without it guiupdate re-reads a stale AmmoData next drag and the clamp never commits.
+	if acemenupanel["CData"][Name].ACEProgrammatic then
+		acemenupanel.AmmoData[Name] = val
+
+		return
+	end
 
 	if acemenupanel.AmmoData[Name] ~= val then
 

--- a/lua/acf/shared/ammocrates/acfcratelist.lua
+++ b/lua/acf/shared/ammocrates/acfcratelist.lua
@@ -751,9 +751,15 @@ ACE.DefineModelData("Cylinder",{
 			Vector(4.24, 4.24, 6),
 		}
 	},
+	-- Constant cross-section swept along Z. Declaring the axis lets
+	-- ACE.Scalable derive the section polygon straight from CustomMesh above,
+	-- so packing and volume both describe the hull the game really builds.
+	ExtrudeAxis = "z",
 	volumefunction = function( L, W, H )
-		local volume = PI * (L / 2) * (W / 2) * H
-		return volume
+		-- The hull is an octagon, not a circle: PI/4 of the bounding box would
+		-- overstate it by ~11%. Ask the mesh instead of hardcoding either one.
+		local ratio = ACE.Scalable.SectionAreaRatio( ACE.ModelData["Cylinder"] )
+		return L * W * H * ratio
 	end
 })
 

--- a/lua/acf/shared/sh_ace_scalable.lua
+++ b/lua/acf/shared/sh_ace_scalable.lua
@@ -34,6 +34,223 @@ function Scalable.ShapeAllowed(shape, def)
 end
 
 ------------------------------------------------------------------
+-- Cross-section geometry.
+--
+-- A shape whose ModelData carries an `ExtrudeAxis` is a prism: constant
+-- cross-section swept along that axis. Everything below derives that
+-- cross-section from the shape's own `CustomMesh`, so the packing maths and
+-- the volume maths can never drift from the collision hull the game builds.
+-- Shapes without an ExtrudeAxis are treated as their full bounding box.
+------------------------------------------------------------------
+
+local SectionCache = {}
+
+local AxisPlane = {
+	x = { "y", "z" },
+	y = { "x", "z" },
+	z = { "x", "y" },
+}
+
+-- Monotone chain hull of 2D points, returned counter-clockwise.
+local function ConvexHull(pts)
+	table.sort(pts, function(a, b)
+		if a[1] ~= b[1] then return a[1] < b[1] end
+		return a[2] < b[2]
+	end)
+
+	local function Cross(o, a, b)
+		return (a[1] - o[1]) * (b[2] - o[2]) - (a[2] - o[2]) * (b[1] - o[1])
+	end
+
+	local function Build(source)
+		local out = {}
+		for i = 1, #source do
+			local p = source[i]
+			while #out >= 2 and Cross(out[#out - 1], out[#out], p) <= 0 do
+				out[#out] = nil
+			end
+			out[#out + 1] = p
+		end
+		out[#out] = nil -- drop the shared endpoint
+		return out
+	end
+
+	local reversed = {}
+	for i = #pts, 1, -1 do reversed[#reversed + 1] = pts[i] end
+
+	local lower, upper = Build(pts), Build(reversed)
+	for i = 1, #upper do lower[#lower + 1] = upper[i] end
+	return lower
+end
+
+--- Normalized convex cross-section of a prism shape.
+-- Projects the shape's CustomMesh onto the plane perpendicular to its
+-- ExtrudeAxis and hulls it, then divides out the mesh's half-extent so the
+-- result is expressed in units of "fraction of the bounding box half-width".
+-- @param md ModelData table (see ACE.DefineModelData).
+-- @return Array of {u, v} points counter-clockwise, or nil for a plain box.
+function Scalable.SectionPolygon(md)
+	if not md or not md.ExtrudeAxis then return end
+
+	local cached = SectionCache[md]
+	if cached ~= nil then
+		return cached or nil
+	end
+
+	local plane = AxisPlane[md.ExtrudeAxis]
+	local half  = (md.DefaultSize or 12) * 0.5
+	if not plane or half <= 0 or not md.CustomMesh then
+		SectionCache[md] = false
+		return
+	end
+
+	local seen, pts = {}, {}
+	for _, hull in ipairs(md.CustomMesh) do
+		for _, vert in ipairs(hull) do
+			local u, v = vert[plane[1]] / half, vert[plane[2]] / half
+			-- Collapse the two end caps onto one another; they are identical.
+			local key = string.format("%.4f:%.4f", u, v)
+			if not seen[key] then
+				seen[key] = true
+				pts[#pts + 1] = { u, v }
+			end
+		end
+	end
+
+	if #pts < 3 then
+		SectionCache[md] = false
+		return
+	end
+
+	local poly = ConvexHull(pts)
+	SectionCache[md] = poly
+	return poly
+end
+
+--- Fraction of its bounding box a prism shape's cross-section fills.
+-- 1 for a box, 2*sqrt(2)/4 ~= 0.707 for the eight-sided cylinder hull.
+-- Use this rather than a hand-written constant so the number always describes
+-- the mesh that actually exists.
+function Scalable.SectionAreaRatio(md)
+	local poly = Scalable.SectionPolygon(md)
+	if not poly then return 1 end
+
+	local area = 0
+	for i = 1, #poly do
+		local a, b = poly[i], poly[(i % #poly) + 1]
+		area = area + (a[1] * b[2] - b[1] * a[2])
+	end
+	-- Normalized coords span [-1, 1] on both axes, so the bounding box area is 4.
+	return math.abs(area) * 0.5 / 4
+end
+
+local EPS = 1e-9
+local MAX_ROWS = 4096
+
+-- Convex polygon as inward half-planes a*u + b*v <= c, scaled to the real
+-- half-extents. Cached per (md, halfU, halfV) would churn; building it is cheap
+-- (eight edges) and capacity is only rebuilt on a crate edit.
+local function HalfPlanes(poly, halfU, halfV)
+	local planes = {}
+	for i = 1, #poly do
+		local p1, p2 = poly[i], poly[(i % #poly) + 1]
+		local u1, v1 = p1[1] * halfU, p1[2] * halfV
+		local u2, v2 = p2[1] * halfU, p2[2] * halfV
+		local du, dv = u2 - u1, v2 - v1
+		planes[#planes + 1] = { dv, -du, dv * u1 - du * v1 }
+	end
+	return planes
+end
+
+-- Horizontal extent of the section at a given v, or nil if that v is outside.
+local function SpanAt(planes, v)
+	local lo, hi = -math.huge, math.huge
+	for i = 1, #planes do
+		local a, b, c = planes[i][1], planes[i][2], planes[i][3]
+		if math.abs(a) < EPS then
+			if b * v > c + EPS then return end
+		else
+			local bound = (c - b * v) / a
+			if a > 0 then
+				if bound < hi then hi = bound end
+			else
+				if bound > lo then lo = bound end
+			end
+		end
+	end
+	if lo > hi then return end
+	return lo, hi
+end
+
+-- Cells of cellU x cellV that fit entirely inside the section, for one grid phase.
+local function CountPhase(planes, halfV, cellU, cellV, offU, offV)
+	local jMin = math.floor((-halfV - offV) / cellV)
+	local jMax = math.ceil((halfV - offV) / cellV)
+	if jMax - jMin > MAX_ROWS then return end
+
+	local total = 0
+	for j = jMin, jMax do
+		local vLo = j * cellV + offV
+		local vHi = vLo + cellV
+
+		local loA, hiA = SpanAt(planes, vLo)
+		if loA then
+			local loB, hiB = SpanAt(planes, vHi)
+			if loB then
+				local lo = math.max(loA, loB)
+				local hi = math.min(hiA, hiB)
+				if hi > lo then
+					-- Cells are [k*cellU + offU, (k+1)*cellU + offU].
+					local kMin = math.ceil((lo - offU) / cellU - EPS)
+					local kMax = math.floor((hi - offU) / cellU + EPS) - 1
+					if kMax >= kMin then total = total + (kMax - kMin + 1) end
+				end
+			end
+		end
+	end
+	return total
+end
+
+--- How many cellU x cellV cells fit entirely inside a shape's cross-section.
+-- This is a real packing count, not a volume fraction: a cell whose corner
+-- falls outside the section is lost completely, which is what actually happens
+-- to a shell that overhangs the wall of a cylindrical crate.
+-- Falls back to the plain box count for shapes with no cross-section.
+-- @param md ModelData table, or nil for a box.
+-- @param sizeU, sizeV Full bounding-box extents on the section's two axes.
+-- @param cellU, cellV Footprint of one item on those same two axes.
+-- @return Integer cell count.
+function Scalable.SectionFit(md, sizeU, sizeV, cellU, cellV)
+	if cellU <= 0 or cellV <= 0 then return 0 end
+
+	local poly = Scalable.SectionPolygon(md)
+	if not poly then
+		return math.floor(sizeU / cellU) * math.floor(sizeV / cellV)
+	end
+
+	local halfU, halfV = sizeU * 0.5, sizeV * 0.5
+	local planes = HalfPlanes(poly, halfU, halfV)
+
+	-- Phase matters: for few items across, a grid centred on the axis and one
+	-- straddling it give different counts. Take whichever packs better.
+	local best = 0
+	for _, offU in ipairs({ 0, -cellU * 0.5 }) do
+		for _, offV in ipairs({ 0, -cellV * 0.5 }) do
+			local count = CountPhase(planes, halfV, cellU, cellV, offU, offV)
+			if not count then
+				-- Section too finely divided to enumerate; fall back to the area
+				-- estimate, which is accurate in exactly that limit.
+				local ratio = Scalable.SectionAreaRatio(md)
+				return math.floor(math.floor(sizeU / cellU) * math.floor(sizeV / cellV) * ratio)
+			end
+			if count > best then best = count end
+		end
+	end
+
+	return best
+end
+
+------------------------------------------------------------------
 -- Server-side spawn glue. Kept behind SERVER because it touches
 -- Entity/ACF; ShapeAllowed above stays shared so the menu can use it.
 ------------------------------------------------------------------

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -144,7 +144,6 @@ function ENT:Initialize()
 	self.Caliber             = 1
 	self.RoFMul              = 1
 	self.CrateShape          = "Box"	-- Scalable crate shape; overwritten on spawn for shaped crates
-	self.VolumeRatio         = 1		-- Fraction of the bounding box the shape fills (Box = 1)
 	self.LastMass            = 1
 
 	self.Inputs              = Wire_CreateInputs( self, Inputs ) --, "Fuse Length"
@@ -300,8 +299,8 @@ end
 
 do
 
-	-- Shapes a scalable crate is allowed to take. Box is the default; Cylinder packs the
-	-- same bounding box but only holds the round count its volume allows (see VolumeRatio).
+	-- Shapes a scalable crate is allowed to take. Box is the default; a shaped crate keeps
+	-- the same bounding box but packs shells against its real cross-section instead.
 	-- Keep this in sync with the shape list offered in the crate menu (cl_acfmenu_gui.lua).
 	local CrateShapes = {
 		Box      = true,
@@ -379,9 +378,6 @@ do
 					local ShapeVolume = ModelData.volumefunction(Scale.x, Scale.y, Scale.z)
 
 					Ammo.CrateShape  = Shape
-					-- Fraction of the bounding box this shape actually fills, used to scale round
-					-- capacity so a cylinder holds less than the box it fits inside.
-					Ammo.VolumeRatio = BoxVolume > 0 and (ShapeVolume / BoxVolume) or 1
 
 					-- Store the normalized id so a dupe keeps the shape (Box stays "L:W:H" for back-compat).
 					Id = Shape == "Box"
@@ -710,31 +706,37 @@ do
 
 			end
 
-			-- Calculate the capacity based on the dimensions of the entity and the dimensions of the ammo
-			local cap1 = Floor(Dimensions.x / shellLength) * Floor(Dimensions.y / width) * Floor(Dimensions.z / width)
-			local cap2 = Floor(Dimensions.y / shellLength) * Floor(Dimensions.x / width) * Floor(Dimensions.z / width)
-			local cap3 = Floor(Dimensions.z / shellLength) * Floor(Dimensions.x / width) * Floor(Dimensions.y / width)
+			-- Calculate the capacity based on the dimensions of the entity and the dimensions of the ammo.
+			-- Shells are packed on a grid in all three orientations and the best one wins. For a
+			-- shaped crate the grid is clipped to the real cross-section, so a shell overhanging a
+			-- cylinder's wall is lost outright rather than discounted -- see ACE.Scalable.SectionFit.
+			local ShapeData = ACE.ModelData[self.CrateShape or "Box"]
+			local SectionFit = ACE.Scalable.SectionFit
+
+			-- The three orientations the box packer has always tried: the shell's long side
+			-- laid along X, along Y, or standing up Z. Listed as the (X, Y, Z) extents of one
+			-- shell. A shaped crate is a prism extruded along Z, so the X and Y extents are
+			-- the ones a rounded wall can clip; the Z extent just stacks.
+			local function BestFit( a, b, c )
+				local best = 0
+				for _, side in ipairs({ {a, b, c}, {b, a, c}, {b, c, a} }) do
+					local count = SectionFit(ShapeData, Dimensions.x, Dimensions.y, side[1], side[2])
+						* Floor(Dimensions.z / side[3])
+					if count > best then best = count end
+				end
+				return best
+			end
+
+			local FCap = BestFit(shellLength, width, width)
 
 			--Split the shell in 2, leave the other piece next to it.
-			local piececap1 = Floor(Dimensions.x / (shellLength / 2)) * Floor(Dimensions.y / (width * 2)) * Floor(Dimensions.z / width)
-			local piececap2 = Floor(Dimensions.y / (shellLength / 2)) * Floor(Dimensions.x / (width * 2)) * Floor(Dimensions.z / width)
-			local piececap3 = Floor(Dimensions.z / (shellLength / 2)) * Floor(Dimensions.x / (width * 2)) * Floor(Dimensions.y / width)
-
-			local FCap	= MaxValue(cap1,cap2,cap3)
-			local FpieceCap = MaxValue(piececap1,piececap2,piececap3)
+			local FpieceCap = BestFit(shellLength / 2, width * 2, width)
 
 			--Why would you need the 2 piece for rounds below 50mm? Unless you want legos there....
 			--Missiles & bombs are excluded from using this method...
 			if AmmoGunData.caliber >= 5 and WeaponType ~= "missile" and FpieceCap > FCap and self.BulletData.TwoPiece > 0 then
 				FCap = FpieceCap
 				self.IsTwoPiece = true
-			end
-
-			-- Shells are packed into the bounding box above; scale the count down to the fraction
-			-- the actual shape fills (Box = 1). Keep at least one round so a shaped crate is usable.
-			local Ratio = self.VolumeRatio or 1
-			if Ratio < 1 and FCap > 0 then
-				FCap = MaxValue(Floor(FCap * Ratio), 1)
 			end
 
 			Capacity	= FCap

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -143,6 +143,8 @@ function ENT:Initialize()
 	self.AmmoMassMax         = 1
 	self.Caliber             = 1
 	self.RoFMul              = 1
+	self.CrateShape          = "Box"	-- Scalable crate shape; overwritten on spawn for shaped crates
+	self.VolumeRatio         = 1		-- Fraction of the bounding box the shape fills (Box = 1)
 	self.LastMass            = 1
 
 	self.Inputs              = Wire_CreateInputs( self, Inputs ) --, "Fuse Length"
@@ -298,11 +300,38 @@ end
 
 do
 
+	-- Shapes a scalable crate is allowed to take. Box is the default; Cylinder packs the
+	-- same bounding box but only holds the round count its volume allows (see VolumeRatio).
+	-- Keep this in sync with the shape list offered in the crate menu (cl_acfmenu_gui.lua).
+	local CrateShapes = {
+		Box      = true,
+		Cylinder = true,
+	}
+
 	-- Parses + clamps an "L:W:H" string into a Vector. Shared with fuel tanks and
 	-- scalable explosives (see ACE.Scalable.ParseScale); crates pass the crate size
 	-- limits as their bounds.
 	local function ConvertStringScale( ScaleId )
 		return ACE.Scalable.ParseScale( ScaleId, { min = ACE.CrateMinimumSize, max = ACE.CrateMaximumSize } )
+	end
+
+	-- A scalable crate id is "L:W:H" or "L:W:H:Shape". Splits off the optional shape token
+	-- (defaulting to Box), validates it, and returns the clamped size Vector plus the shape.
+	-- A Vector id (from an older dupe) is passed straight through as a Box crate.
+	local function ParseCrateScale( Id )
+		if isvector( Id ) then return ConvertStringScale( Id ), "Box" end
+		if not isstring( Id ) then return nil, "Box" end
+
+		local Shape = "Box"
+		local parts = string.Explode( ":", Id )
+		if #parts >= 4 then
+			Shape = parts[4]
+			Id = parts[1] .. ":" .. parts[2] .. ":" .. parts[3]
+		end
+
+		if not CrateShapes[Shape] then Shape = "Box" end
+
+		return ConvertStringScale( Id ), Shape
 	end
 
 	-- If the incoming Id belongs to an invalid ammo crate, but belongs to the legacy crates list, convert it into its scalable counterpart.
@@ -334,20 +363,32 @@ do
 			if not ACE_CheckAmmo( Id ) then
 
 				local Scale
+				local Shape = "Box"
 
 				if isstring(Id) and LegacyAmmoTable[Id] then
 					Scale = CreateLegacyScale(Id, Ammo)
 				else
-					Scale = ConvertStringScale(Id)
+					Scale, Shape = ParseCrateScale(Id)
 				end
 
 				if isvector(Scale) then
 
-					local ModelData = ACE.ModelData["Box"]
+					local ModelData = ACE.ModelData[Shape] or ACE.ModelData["Box"]
 
-					Id = Scale
+					local BoxVolume   = Scale.x * Scale.y * Scale.z
+					local ShapeVolume = ModelData.volumefunction(Scale.x, Scale.y, Scale.z)
+
+					Ammo.CrateShape  = Shape
+					-- Fraction of the bounding box this shape actually fills, used to scale round
+					-- capacity so a cylinder holds less than the box it fits inside.
+					Ammo.VolumeRatio = BoxVolume > 0 and (ShapeVolume / BoxVolume) or 1
+
+					-- Store the normalized id so a dupe keeps the shape (Box stays "L:W:H" for back-compat).
+					Id = Shape == "Box"
+						and (Scale.x .. ":" .. Scale.y .. ":" .. Scale.z)
+						or (Scale.x .. ":" .. Scale.y .. ":" .. Scale.z .. ":" .. Shape)
 					Model = ModelData.Model
-					Weight = (Scale.x * Scale.y * Scale.z) / 200
+					Weight = ShapeVolume / 200
 					Dimensions = Scale
 
 					local DefaultSize    = ModelData.DefaultSize
@@ -528,6 +569,9 @@ function ENT:UpdateOverlayText()
 
 			local dims = x .. "x" .. y .. "x" .. z
 			text = text .. "\n\n Size: " .. dims
+			if self.CrateShape and self.CrateShape ~= "Box" then
+				text = text .. "\n Shape: " .. self.CrateShape
+			end
 		end
 
 		if self.IsTwoPiece then
@@ -684,6 +728,13 @@ do
 			if AmmoGunData.caliber >= 5 and WeaponType ~= "missile" and FpieceCap > FCap and self.BulletData.TwoPiece > 0 then
 				FCap = FpieceCap
 				self.IsTwoPiece = true
+			end
+
+			-- Shells are packed into the bounding box above; scale the count down to the fraction
+			-- the actual shape fills (Box = 1). Keep at least one round so a shaped crate is usable.
+			local Ratio = self.VolumeRatio or 1
+			if Ratio < 1 and FCap > 0 then
+				FCap = MaxValue(Floor(FCap * Ratio), 1)
 			end
 
 			Capacity	= FCap

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -374,7 +374,6 @@ do
 
 					local ModelData = ACE.ModelData[Shape] or ACE.ModelData["Box"]
 
-					local BoxVolume   = Scale.x * Scale.y * Scale.z
 					local ShapeVolume = ModelData.volumefunction(Scale.x, Scale.y, Scale.z)
 
 					Ammo.CrateShape  = Shape
@@ -663,7 +662,6 @@ do
 	end
 
 	local Floor = math.floor
-	local MaxValue = math.max
 	local toInch = 2.54		--Number used for cm -> inche conversion
 
 	function ENT:BuildAmmoCapacity()

--- a/tests/lua/ace_cylinder_packing_luajit_selftest.lua
+++ b/tests/lua/ace_cylinder_packing_luajit_selftest.lua
@@ -1,0 +1,235 @@
+-- Offline coverage for ACE.Scalable's cross-section packing maths.
+--
+-- The point of this file is that capacity for a non-box crate is a real packing
+-- count, not a volume fraction. It checks the section derived from the shipped
+-- Cylinder mesh, and cross-checks ACE.Scalable.SectionFit against a brute-force
+-- counter written independently of the span/half-plane routine it is testing.
+local repo = assert(arg[1], "usage: luajit ace_cylinder_packing_luajit_selftest.lua <ace-repo>")
+
+ACE = {}
+ACE.ModelData = {}
+ACE.Weapons = { Ammo = {}, LegacyAmmo = {}, Guns = {} }
+
+function Vector(x, y, z)
+	return { x = x or 0, y = y or 0, z = z or 0 }
+end
+
+function ACE.DefineModelData(id, data)
+	data.id = id
+	ACE.ModelData[id] = data
+	ACE.ModelData[data.Model] = data
+end
+ACE_DefineModelData = ACE.DefineModelData
+
+dofile(repo .. "/lua/acf/shared/sh_ace_scalable.lua")
+dofile(repo .. "/lua/acf/shared/ammocrates/acfcratelist.lua")
+
+local Scalable = ACE.Scalable
+local Cylinder = assert(ACE.ModelData["Cylinder"], "Cylinder ModelData missing")
+
+local checks = 0
+local function check(ok, msg)
+	checks = checks + 1
+	if not ok then
+		io.stderr:write("FAIL: " .. msg .. "\n")
+		os.exit(1)
+	end
+end
+
+local function near(a, b, eps)
+	return math.abs(a - b) <= (eps or 1e-9)
+end
+
+------------------------------------------------------------------
+-- The section itself
+------------------------------------------------------------------
+
+check(Cylinder.ExtrudeAxis == "z", "Cylinder must declare ExtrudeAxis for the packer to see a section")
+
+local poly = Scalable.SectionPolygon(Cylinder)
+check(poly ~= nil, "Cylinder must produce a section polygon")
+check(#poly == 8, "Cylinder hull is eight-sided, got " .. tostring(#poly))
+
+-- The mesh puts vertices at (+-1, 0), (0, +-1) and (+-k, +-k) with k = 4.24/6.
+-- Shoelace over those eight points collapses to exactly k, so the fraction of the
+-- bounding box the hull fills is derivable by hand and does not need the code
+-- under test to agree with itself.
+local k = 4.24 / 6
+local ratio = Scalable.SectionAreaRatio(Cylinder)
+check(near(ratio, k, 1e-9), string.format("octagon area ratio: expected %.9f, got %.9f", k, ratio))
+
+-- The bug this replaced: PI/4 describes a circle, not the hull the game builds.
+check(not near(ratio, math.pi / 4, 1e-3), "area ratio must not be the old PI/4 constant")
+check(ratio < math.pi / 4, "octagon must fill less of its box than a circle would")
+
+-- A box has no section and must fill its bounding box exactly.
+check(Scalable.SectionPolygon(nil) == nil, "nil ModelData has no section")
+check(Scalable.SectionAreaRatio(nil) == 1, "a box fills its whole bounding box")
+
+------------------------------------------------------------------
+-- Independent brute-force packer
+--
+-- Deliberately written the naive way: build the scaled polygon, walk every
+-- candidate cell, and accept it only when all four corners are inside. It shares
+-- no code with SectionFit's span/half-plane path.
+------------------------------------------------------------------
+
+local EPS = 1e-9
+
+local function scaledPoly(p, halfU, halfV)
+	local out = {}
+	for i = 1, #p do
+		out[i] = { p[i][1] * halfU, p[i][2] * halfV }
+	end
+	return out
+end
+
+-- CCW polygon: a point is inside when it is left of (or on) every edge.
+local function inside(sp, u, v)
+	for i = 1, #sp do
+		local a, b = sp[i], sp[(i % #sp) + 1]
+		local cross = (b[1] - a[1]) * (v - a[2]) - (b[2] - a[2]) * (u - a[1])
+		if cross < -EPS then return false end
+	end
+	return true
+end
+
+local function bruteFit(md, sizeU, sizeV, cellU, cellV)
+	local p = Scalable.SectionPolygon(md)
+	if not p then
+		return math.floor(sizeU / cellU) * math.floor(sizeV / cellV)
+	end
+
+	local halfU, halfV = sizeU * 0.5, sizeV * 0.5
+	local sp = scaledPoly(p, halfU, halfV)
+
+	local best = 0
+	for _, offU in ipairs({ 0, -cellU * 0.5 }) do
+		for _, offV in ipairs({ 0, -cellV * 0.5 }) do
+			local total = 0
+			local kMin = math.floor((-halfU - offU) / cellU) - 1
+			local kMax = math.ceil((halfU - offU) / cellU) + 1
+			local jMin = math.floor((-halfV - offV) / cellV) - 1
+			local jMax = math.ceil((halfV - offV) / cellV) + 1
+
+			for j = jMin, jMax do
+				local v0 = j * cellV + offV
+				local v1 = v0 + cellV
+				for kk = kMin, kMax do
+					local u0 = kk * cellU + offU
+					local u1 = u0 + cellU
+					if inside(sp, u0, v0) and inside(sp, u1, v0)
+						and inside(sp, u0, v1) and inside(sp, u1, v1) then
+						total = total + 1
+					end
+				end
+			end
+
+			if total > best then best = total end
+		end
+	end
+
+	return best
+end
+
+------------------------------------------------------------------
+-- Cross-check across a sweep
+------------------------------------------------------------------
+
+local sizes = { 24, 36, 48, 60, 96, 100, 137.5 }
+local cells = { 2, 3, 4, 4.5, 6, 8, 11, 14 }
+
+local compared, clipped = 0, 0
+for _, sizeU in ipairs(sizes) do
+	for _, sizeV in ipairs(sizes) do
+		for _, cellU in ipairs(cells) do
+			for _, cellV in ipairs(cells) do
+				local got = Scalable.SectionFit(Cylinder, sizeU, sizeV, cellU, cellV)
+				local want = bruteFit(Cylinder, sizeU, sizeV, cellU, cellV)
+				check(got == want, string.format(
+					"SectionFit(%.1f x %.1f, cell %.1f x %.1f): expected %d, got %d",
+					sizeU, sizeV, cellU, cellV, want, got))
+
+				-- A cylinder can never hold more than its bounding box, and for
+				-- these sizes it must actually lose something to the wall.
+				local box = math.floor(sizeU / cellU) * math.floor(sizeV / cellV)
+				check(got <= box, "cylinder count must not exceed the box count")
+				if got < box then clipped = clipped + 1 end
+
+				compared = compared + 1
+			end
+		end
+	end
+end
+
+check(clipped > compared * 0.9, "the sweep should be dominated by cases the wall actually clips")
+
+------------------------------------------------------------------
+-- Box shapes must be untouched
+------------------------------------------------------------------
+
+for _, sizeU in ipairs(sizes) do
+	for _, cellU in ipairs(cells) do
+		local got = Scalable.SectionFit(nil, sizeU, sizeU, cellU, cellU)
+		local want = math.floor(sizeU / cellU) * math.floor(sizeU / cellU)
+		check(got == want, string.format(
+			"box SectionFit(%.1f, cell %.1f): expected %d, got %d", sizeU, cellU, want, got))
+	end
+end
+
+------------------------------------------------------------------
+-- Properties a volume fraction could not reproduce
+------------------------------------------------------------------
+
+-- A cell the size of the whole bounding box fits a box and never a cylinder:
+-- its corners are the four points the octagon cuts off.
+check(Scalable.SectionFit(Cylinder, 48, 48, 48, 48) == 0, "bbox-sized cell cannot fit in the hull")
+check(Scalable.SectionFit(nil, 48, 48, 48, 48) == 1, "bbox-sized cell fits a box exactly once")
+
+-- Degenerate input must not divide by zero or loop.
+check(Scalable.SectionFit(Cylinder, 48, 48, 0, 4) == 0, "zero cell width yields no cells")
+check(Scalable.SectionFit(Cylinder, 48, 48, 4, -1) == 0, "negative cell height yields no cells")
+
+-- The packed fraction is not a constant: it depends on how many cells span the
+-- section, which is the whole reason a single scalar was wrong. Few cells across
+-- lose proportionally more than many do.
+local function fraction(size, cell)
+	local box = math.floor(size / cell) * math.floor(size / cell)
+	return Scalable.SectionFit(Cylinder, size, size, cell, cell) / box
+end
+
+local coarse = fraction(48, 12)  -- 4 across
+local fine   = fraction(480, 12) -- 40 across
+check(fine > coarse, string.format(
+	"a finer grid must waste less of the section (4 across %.3f, 40 across %.3f)", coarse, fine))
+check(fine < ratio + 1e-6, "even a fine grid cannot beat the section's own area fraction")
+
+-- The section stretches with the crate, so transposing both the crate and the
+-- cell must land on the same count. This is the symmetry the old flat ratio did
+-- have; breaking it would mean the axes had got crossed somewhere.
+for _, case in ipairs({
+	{ 24, 96, 14, 4 },
+	{ 48, 48, 14, 4 },
+	{ 96, 36, 6, 11 },
+	{ 137.5, 60, 4.5, 8 },
+}) do
+	local sizeU, sizeV, cellU, cellV = case[1], case[2], case[3], case[4]
+	check(Scalable.SectionFit(Cylinder, sizeU, sizeV, cellU, cellV)
+		== Scalable.SectionFit(Cylinder, sizeV, sizeU, cellV, cellU),
+		string.format("transposing %.1fx%.1f cell %.1fx%.1f must not change the count",
+			sizeU, sizeV, cellU, cellV))
+end
+
+-- Orientation changes what the wall costs, which is exactly what one scalar
+-- could not express. These two are the figures quoted in the writeup for a 48
+-- crate: shells stood on end keep 56% of the box count, laid flat only 50%.
+local standing = Scalable.SectionFit(Cylinder, 48, 48, 4, 4)
+local flat     = Scalable.SectionFit(Cylinder, 48, 48, 14, 4)
+check(standing == 81, "48 crate, 4x4 section: expected 81, got " .. standing)
+check(flat == 18, "48 crate, 14x4 section: expected 18, got " .. flat)
+check(near(standing / 144, 0.5625, 1e-9), "standing shells should keep 56% of the box count")
+check(near(flat / 36, 0.5, 1e-9), "flat shells should keep 50% of the box count")
+check(standing / 144 > flat / 36, "the wall must cost the two orientations differently")
+
+print(string.format("ACE cylinder packing self-test: PASS (%d assertions, %d packings cross-checked)",
+	checks, compared))


### PR DESCRIPTION
Took from suggestions.

Initially just wanted to add extra model path, so it would take couple mins to do, when I did that I noticed that cylinder shape had the same amount of ammo as the box one, which was completely wrong. Then I decided to use AI to figure out why that happened:


AI text below:

---

**Why the cylinder held box amounts**

Nothing in the capacity path knew about crate shape. `VolumeRatio` and `CrateShapes` didn't exist before this branch, so a cylinder ran the box arithmetic unchanged — the model was round, the maths wasn't.

The first fix was a single scalar: `VolumeRatio = ShapeVolume / BoxVolume`, π/4 ≈ 0.785, applied to the winning box packing. That's wrong three separate ways:

1. **It's blind to orientation.** A cylinder loses nothing along its axis and everything at its wall, so the penalty depends on which way the shells point. The old code picked the best box packing *first* and applied one flat number afterwards, so it chose a winner before it could know what the shape would cost.
2. **A volume fraction isn't a count.** Shells are rigid boxes on a grid — one whose corner crosses the wall is lost entirely, not shaved proportionally. A scalar can only shave. The gap is worst when few shells span the diameter and never closes: even at 40 across, the real packed fraction is 66%, not 78.5%.
3. **The hull isn't round.** `CustomMesh` is 8 vertices per cap, so the collision hull shells sit in — and shots trace against — is an octagon at 70.7% of its bounding box. Capacity was computing against a circle while `ApplyShape` prefers `phys:GetVolume()`, so mass and points could read the octagon while capacity read the circle.

**What the fix does**

Derives the cross-section from `CustomMesh` instead of hardcoding either constant. `SectionPolygon` projects the mesh perpendicular to `ExtrudeAxis` and hulls it; `SectionFit` counts cells fully inside, testing both grid phases. Clipping happens per orientation and *before* the winner is chosen, which is the part that matters. Two-piece comparison now runs on clipped numbers too, instead of deciding whether to split shells from box counts and only then discovering the crate was round. Shapes with no `ExtrudeAxis` fall through to plain floor division, so box crates run identical arithmetic. Counting is per row, not per cell — for a convex section the valid span at any height is one interval, so a 250-unit crate of small-calibre rounds resolves in a few hundred iterations, and only on crate edit.

| Crate | Shell | Box | Old | New | Change |
|---|---|---|---|---|---|
| 48×48×48 | 14×4 | 432 | 339 | 243 | −28% |
| 48×48×48 | 6×2 | 4608 | 3619 | 2896 | −20% |
| 100×100×100 | 20×6 | 1280 | 1005 | 840 | −16% |
| 24×24×96 | 14×4 | 216 | 169 | 96 | −43% |
| 96×24×24 | 14×4 | 216 | 169 | 108 | −36% |
| 60×30×60 | 10×3 | 1200 | 942 | 690 | −27% |
| 250×250×250 | 30×8 | 7688 | 6038 | 5064 | −16% |

Corrections are largest on unevenly scaled crates — 24×24×96 was overcounting by 76%, because a tall narrow cylinder has only six shells spanning its diameter and loses far more than a fifth to the wall. Box crates verified identical (432 before and after, 48³ with a 14×4 shell).

**Test coverage.** `tests/lua/ace_cylinder_packing_luajit_selftest.lua` cross-checks `SectionFit` against a brute-force counter written against the polygon directly, sharing no code with the span/half-plane routine it verifies — 3136 packings across a sweep of crate and shell sizes. It also pins the section's area fraction to the value the shipped mesh implies (4.24/6, derivable by hand via the shoelace formula over its eight vertices) rather than to whatever the code happens to return, checks box shapes still run exact floor division, and locks the two orientation figures quoted above. The assertions were confirmed to bite: dropping the straddling grid phase and restoring the old π/4 constant each fail the suite.

**Still not verified in game.** The geometry is checked and the files load clean under LuaJIT, but nothing here has been spawned on a server. This is also a capacity reduction for any cylinder crate already in use.

---

Would love some guidance, as im not super strong with geometry. i've asked it to prove what it did there, it creates the html file, it looks correct to what I've encountered in game and it looks correct now.
[cylinder-packing.html](https://github.com/user-attachments/files/30884634/cylinder-packing.html)

Also applies the fix from here: https://github.com/ACE-Project-Team/ArmoredCombatExtended/pull/334

Two things worth deciding:

- **Octagon or real cylinder.** The volume now matches the eight-sided hull, which is the conservative fix. The alternative is giving the mesh more vertices so it is actually round — better looking and about 11% more capacious, but it changes the collision shape, so it is a separate call.

<sub>Supersedes #335, which was opened from a branch whose files had been committed with CRLF line endings — that made the whole file read as changed and produced an unresolvable conflict against `dev`. Same change, rebuilt on current `dev` with the line endings left alone.</sub>
