### PR TITLE
Add legacy ACF compatibility bridges for ACE extensions

### DIFF
--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -684,6 +684,14 @@ if ACECompatibilityView then
     ACF_GetHitAngle = ACF_GetHitAngle or ACE_GetHitAngle
     ACF_GetLinkedWheels = ACF_GetLinkedWheels or ACE_GetLinkedWheels
     ACF_SendNotify = ACF_SendNotify or ACE_SendNotify
+
+    -- ACE Weapons+ still consumes the old ACF calculation entry points. Keep
+    -- these aliases on the compatibility view only; an independently loaded
+    -- ACF installation retains ownership of its own globals.
+    ACF_GetPhysicalParent = ACF_GetPhysicalParent or ACE_GetPhysicalParent
+    ACF_Kinetic = ACF_Kinetic or ACE_Kinetic
+    ACF_MuzzleVelocity = ACF_MuzzleVelocity or ACE_MuzzleVelocity
+    ACF_HE = ACF_HE or ACE_HE
 end
 
 AddCSLuaFile("autorun/acf_missile/folder.lua")

--- a/lua/effects/acf_scaled_explosion/init.lua
+++ b/lua/effects/acf_scaled_explosion/init.lua
@@ -1,0 +1,3 @@
+-- Legacy effect name used by ACF-compatible weapon extensions, including ACE Weapons+.
+-- The effect implementation remains owned by ACE's namespaced effect.
+include("effects/ace_scaled_explosion/init.lua")

--- a/tests/python/test_legacy_extension_compat.py
+++ b/tests/python/test_legacy_extension_compat.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import unittest
+
+
+REPO = Path(__file__).resolve().parents[2]
+GLOBALS = REPO / "lua" / "autorun" / "acf_globals.lua"
+
+
+class LegacyExtensionCompatibilityTests(unittest.TestCase):
+    def test_ace_weapons_plus_legacy_calculation_bridges_are_guarded(self):
+        source = GLOBALS.read_text(encoding="utf-8")
+        bridge_start = source.index("-- ACE Weapons+ still consumes")
+        bridge = source[bridge_start:]
+
+        self.assertIn("if ACECompatibilityView then", source[:bridge_start])
+        for symbol, implementation in (
+            ("ACF_GetPhysicalParent", "ACE_GetPhysicalParent"),
+            ("ACF_Kinetic", "ACE_Kinetic"),
+            ("ACF_MuzzleVelocity", "ACE_MuzzleVelocity"),
+            ("ACF_HE", "ACE_HE"),
+        ):
+            with self.subTest(symbol=symbol):
+                self.assertIn(f"{symbol} = {symbol} or {implementation}", bridge)
+
+    def test_legacy_scaled_explosion_effect_name_is_available(self):
+        alias = REPO / "lua" / "effects" / "acf_scaled_explosion" / "init.lua"
+        self.assertEqual(
+            alias.read_text(encoding="utf-8").strip(),
+            '-- Legacy effect name used by ACF-compatible weapon extensions, including ACE Weapons+.\n'
+            '-- The effect implementation remains owned by ACE\'s namespaced effect.\n'
+            'include("effects/ace_scaled_explosion/init.lua")',
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/python/test_namespace_refactor.py
+++ b/tests/python/test_namespace_refactor.py
@@ -519,7 +519,8 @@ class NamespaceRefactorTests(unittest.TestCase):
                 source = source.replace("ACF_E2_LinkTables", "")
                 for compatibility_name in (
                     "ACF_CalcArmor", "ACF_Check", "ACF_CheckClips",
-                    "ACF_GetHitAngle", "ACF_GetLinkedWheels", "ACF_SendNotify"
+                    "ACF_GetHitAngle", "ACF_GetLinkedWheels", "ACF_SendNotify",
+                    "ACF_GetPhysicalParent", "ACF_Kinetic", "ACF_MuzzleVelocity", "ACF_HE",
                 ):
                     source = source.replace(compatibility_name, "")
                 self.assertNotRegex(source, r"(?<![.:])\bACF_[A-Za-z_][A-Za-z0-9_]*")
@@ -532,7 +533,8 @@ class NamespaceRefactorTests(unittest.TestCase):
             ).replace("ACF_E2_LinkTables", "")
             for compatibility_name in (
                 "ACF_CalcArmor", "ACF_Check", "ACF_CheckClips",
-                "ACF_GetHitAngle", "ACF_GetLinkedWheels", "ACF_SendNotify"
+                "ACF_GetHitAngle", "ACF_GetLinkedWheels", "ACF_SendNotify",
+                "ACF_GetPhysicalParent", "ACF_Kinetic", "ACF_MuzzleVelocity", "ACF_HE",
             ):
                 source = source.replace(compatibility_name, "")
             with self.subTest(source=path.relative_to(REPO)):
@@ -686,9 +688,11 @@ class NamespaceRefactorTests(unittest.TestCase):
         for old_name in {
             "acf_ap_impact", "acf_ap_penetration", "acf_ap_ricochet", "acf_bulleteffect",
             "acf_heat_explosion", "acf_missilelaunch", "acf_muzzleflash", "acf_racklaunch",
-            "acf_radar_noise", "acf_scaled_explosion", "acf_smoke",
+            "acf_radar_noise", "acf_smoke",
         }:
             self.assertNotIn(old_name, effect_names)
+
+        self.assertIn("acf_scaled_explosion", effect_names)
 
     def test_deferred_adapters_keep_legacy_compatibility_boundaries(self):
         for relative in (


### PR DESCRIPTION
Adds guarded legacy ACF calculation bridges for ACE Weapons+ when ACE runs without ACF; provides the legacy acf_scaled_explosion effect name while keeping the implementation in ACE; preserves existing ACF Extras sound-path compatibility. Validation: 146 Python tests passed, GMod regression guard passed against upstream/dev, and git diff --check passed. GLuaLint and native GMod runtime tests were unavailable in this checkout.