### PR TITLE
Limit maximum screen shake effect to reasonable values

### DIFF
--- a/lua/acf/shared/sh_ace_functions.lua
+++ b/lua/acf/shared/sh_ace_functions.lua
@@ -7,7 +7,7 @@ include("acf/shared/sh_ace_points_model.lua")
 AddCSLuaFile("acf/shared/sh_ace_manufacturing.lua")
 include("acf/shared/sh_ace_manufacturing.lua")
 
-local floor, Clamp = math.floor, math.Clamp
+local floor, Clamp, min = math.floor, math.Clamp, math.min
 
 -- returns last parent in chain, which has physics
 function ACE_GetPhysicalParent( obj )
@@ -1512,4 +1512,14 @@ function ACE_GetEntPoints(ent)
 
 	local scale = (ACE.PointsModel and ACE.PointsModel.Scale) or 1
 	return (tonumber(ent.ACEPoints) or 0) * scale
+end
+
+if CLIENT then
+	function ACE.ScreenShake(pos, amplitude, frequency, duration, radius, airshake)
+		amplitude = min(amplitude, 200)
+		frequency = Clamp(frequency, 5, 40)
+		duration = min(duration, 5)
+
+		util.ScreenShake(pos, amplitude, frequency, duration, radius, airshake)
+	end
 end

--- a/lua/effects/ace_ap_impact/init.lua
+++ b/lua/effects/ace_ap_impact/init.lua
@@ -140,7 +140,7 @@ function EFFECT:Init( data )
 		if PlayerDist < Energy * 8 and not LocPly:HasGodMode() then
 			local Amp          = math.min(Energy / 350 / math.max(PlayerDist,5), 40)
 			--local Amp          = math.min(self.Radius / 1.5 / math.max(PlayerDist,5),40)
-			util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,2), Energy / 10 , false) --Energy/20
+			ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,2), Energy / 10 , false) --Energy/20
 		end
 	end
 

--- a/lua/effects/ace_ap_penetration/init.lua
+++ b/lua/effects/ace_ap_penetration/init.lua
@@ -167,7 +167,7 @@ function EFFECT:Init( data )
 		if PlayerDist < Energy * 8 and not LocPly:HasGodMode() then
 			local Amp          = math.min(Energy / 250 / math.max(PlayerDist,5),40)
 			--local Amp          = math.min(self.Radius / 1.5 / math.max(PlayerDist,5),40)
-			util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,2), Energy / 10 , false) --Energy/20
+			ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,2), Energy / 10 , false) --Energy/20
 		end
 
 	end

--- a/lua/effects/ace_ap_ricochet/init.lua
+++ b/lua/effects/ace_ap_ricochet/init.lua
@@ -105,7 +105,7 @@ function EFFECT:Init( data )
 		if PlayerDist < Energy  * 10 and not LocPly:HasGodMode() then
 			local Amp          = math.min(Energy / 500 / math.max(PlayerDist,5),40)
 			--local Amp          = math.min(self.Radius / 1.5 / math.max(PlayerDist,5),40)
-			util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,2), Energy / 10 , false) --Energy/20
+			ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,2), Energy / 10 , false) --Energy/20
 		end
 
 	end

--- a/lua/effects/ace_cookoff_puff/init.lua
+++ b/lua/effects/ace_cookoff_puff/init.lua
@@ -22,7 +22,7 @@ function EFFECT:Init( data )
 		if PlayerDist < self.Radius * 10 and not LocalPlayer():HasGodMode() then
 		--if PlayerDist < self.Radius * 10 then
 		local Amp          = math.min(self.Radius * 0.5 / math.max(PlayerDist,1),40)
-		util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, self.Radius / 7.5, 0 , true)
+		ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, self.Radius / 7.5, 0 , true)
 	end
 
 	self.Emitter:Finish()

--- a/lua/effects/ace_muzzleflash/init.lua
+++ b/lua/effects/ace_muzzleflash/init.lua
@@ -85,7 +85,7 @@ function EFFECT:Init( data )
 			if PlayerDist < self.Radius * 4 and not LocPly:HasGodMode() then
 				local Amp          = math.min(Propellant * 1.5 / math.max(PlayerDist,5),40)
 				--local Amp          = math.min(self.Radius / 1.5 / math.max(PlayerDist,5),40)
-				util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,self.Radius / 20), 0 , true)
+				ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, math.min(Amp  * 2,self.Radius / 20), 0 , true)
 			end
 		end
 

--- a/lua/effects/ace_scaled_detonation/init.lua
+++ b/lua/effects/ace_scaled_detonation/init.lua
@@ -175,7 +175,7 @@ function EFFECT:Init( data )
 		if PlayerDist < self.Radius * 10 and not LocalPlayer():HasGodMode() then
 		--if PlayerDist < self.Radius * 10 then
 		local Amp          = math.min(self.Radius * 0.5 / math.max(PlayerDist,1),40)
-		util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, self.Radius / 7.5, 0 , true)
+		ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, self.Radius / 7.5, 0 , true)
 	end
 
 

--- a/lua/effects/ace_scaled_explosion/init.lua
+++ b/lua/effects/ace_scaled_explosion/init.lua
@@ -97,7 +97,7 @@ function EFFECT:Init( data )
 	local PlayerDist = (LocalPlayer():GetPos() - self.Origin):Length() / 20 + 0.001 --Divide by 0 is death, 20 is roughly 39.37 / 2
 	if PlayerDist < self.Radius * 10 and not LocalPlayer():HasGodMode() then
 		local Amp          = math.min(self.Radius * 0.5 / math.max(PlayerDist,1),40)
-		util.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, self.Radius / 7.5, 0 , true)
+		ACE.ScreenShake( self.Origin, 50 * Amp, 1.5 / Amp, self.Radius / 7.5, 0 , true)
 	end
 
 	if IsValid(self.Emitter) then self.Emitter:Finish() end


### PR DESCRIPTION
No more of your screen shake being so intense that your camera disconnects from your head, flies repeatedly into the wall, and persists for a solid 30 seconds because somebody fired a 406 howitzer next to your head

It's funny the first time it happens but awful afterwards
