### PR TITLE
Tweaks + Improved description of missile inputs

### DIFF
--- a/lua/acf/shared/guidances/a_dumb.lua
+++ b/lua/acf/shared/guidances/a_dumb.lua
@@ -12,7 +12,7 @@ ACE.Guidance[ClassName] = this
 
 this.Name = ClassName
 
-this.desc = "This guidance package is empty and provides no control."
+this.desc = "No guidance package. The missile will not make any correctional measures to steer itself or counteract gravity.."
 
 -- an object containing an obj:GetGuidanceOverride(missile, guidance) function
 this.Override = nil

--- a/lua/acf/shared/guidances/b_wire.lua
+++ b/lua/acf/shared/guidances/b_wire.lua
@@ -15,7 +15,7 @@ this.WireLength = (500 * 39.37) ^ 2			-- about 500m
 -- Disables guidance when true
 this.WireSnapped = false
 
-this.desc = "This guidance package is controlled by the launcher, which reads a target-position and steers the munition towards it. Has a limited guidance distance."
+this.desc = "Guidance package for reliably guiding a missile. The guidance cable has a limited range of only 500 meters however the guidance works regardless of line of sight and cannot be jammed."
 
 this.GuidanceWire = nil
 

--- a/lua/acf/shared/guidances/c_antimissile.lua
+++ b/lua/acf/shared/guidances/c_antimissile.lua
@@ -26,7 +26,7 @@ this.HasIRCCM = false
 -- Minimum distance for a target to be considered
 this.MinimumDistance = 393.7	--10m
 
-this.desc = "This guidance package detects a target-position infront of itself, and guides the munition towards it."
+this.desc = "Anti-missile guidance. Will automatically track any missiles it is fired at within the cone. And will coordinate with other missiles to avoid targeting the same missile. Does not track the owner's missiles. Fire and forget."
 
 function this:Init()
 	self.LastSeek = CurTime() - self.SeekDelay - 0.000001

--- a/lua/acf/shared/guidances/d_infrared.lua
+++ b/lua/acf/shared/guidances/d_infrared.lua
@@ -37,7 +37,7 @@ this.MinimumDistance = 200  -- ~5m
 -- Maximum distance for a target to be considered.
 this.MaximumDistance = 20000
 
-this.desc = "This guidance package detects hot targets infront of itself, and guides the munition towards it."
+this.desc = "Guidance package which relies on the heat of the target to guide itself. Will be unable to lock a target if it is not hot enough. Can be defeated by flares. Fire and forget."
 
 this.TTime = 0
 

--- a/lua/acf/shared/guidances/e_laser.lua
+++ b/lua/acf/shared/guidances/e_laser.lua
@@ -13,7 +13,7 @@ this.Name = ClassName
 -- Cone to retain targets within.
 this.ViewCone = 30
 
-this.desc = "This guidance package reads a target-position from the launcher and guides the munition towards it."
+this.desc = "Robust guidance package which uses a laser to guide a missile towards the target position. In order to guide, the seeker must have a clear view of the target position. Cannot be jammed or flared."
 
 
 

--- a/lua/acf/shared/guidances/f_radar.lua
+++ b/lua/acf/shared/guidances/f_radar.lua
@@ -33,7 +33,7 @@ this.HasIRCCM = false
 -- Minimum distance for a target to be considered
 this.MinimumDistance = 393.7	--10m
 
-this.desc = "This guidance package detects a target-position infront of itself, and guides the munition towards it."
+this.desc = "Guidance package that uses forward looking radar to track the target. Weakened by ground clutter. Can be defeated by notching or using chaff. Fire and forget."
 
 --Multiplier for the ground clutter effect.
 this.GCMultiplier = 1

--- a/lua/acf/shared/guidances/g_gps.lua
+++ b/lua/acf/shared/guidances/g_gps.lua
@@ -13,7 +13,7 @@ this.Name = ClassName
 -- An entity with a Position wire-output
 this.InputSource = nil
 
-this.desc = "This guidance package recieves a one-time position and guides to it regardless of LOS."
+this.desc = "A form of guidance that guides directly towards a target point. Programmed at the time of launch and cannot be adjusted after. Will head straight towards the target position regardless of line of sight or seeker cone. Fire and forget."
 
 -- Disables guidance when true
 this.FirstGuidance = true
@@ -50,7 +50,9 @@ function this:GetGuidance(missile)
 			return {TargetPos = nil}
 		end
 
-		self.FirstGuidance = false
+		if missile.MissileActive then
+			self.FirstGuidance = false
+		end
 		self.TargetPos = posVec
 	end
 

--- a/lua/acf/shared/guidances/h_antiradiation.lua
+++ b/lua/acf/shared/guidances/h_antiradiation.lua
@@ -31,7 +31,7 @@ this.HasIRCCM = false
 -- Minimum distance for a target to be considered
 this.MinimumDistance = 393.7	--10m
 
-this.desc = "This guidance package detects a target-position infront of itself, and guides the munition towards it."
+this.desc = "Guidance package that will hone-in on any radar emissions. Capable of targeting Search and Track Radars, Missile Radars, or ECM.  Fire and forget. Only targets devices that are actively emitting."
 
 function this:Init()
 	self.LastSeek = CurTime() - self.SeekDelay - 0.000001

--- a/lua/acf/shared/guidances/i_radarsemi.lua
+++ b/lua/acf/shared/guidances/i_radarsemi.lua
@@ -29,7 +29,7 @@ this.HasIRCCM = false
 -- Minimum distance for a target to be considered
 this.MinimumDistance = 393.7	--10m
 
-this.desc = "This guidance package will guide the missile towards targets acquired by your radars."
+this.desc = "Semi-active radar guidance. Requires a tracking radar to work. Will guide a missile towards any targets detected by your tracking radar but requires keeping the target constantly painted by radar. Cheap."
 
 this.Radars = {} --Contains all owned radars to grab targets from.
 

--- a/lua/acf/shared/guidances/j_topattackir.lua
+++ b/lua/acf/shared/guidances/j_topattackir.lua
@@ -41,7 +41,7 @@ this.LargestDist = 0
 
 this.TopAttackFactor = 1
 
-this.desc = "This guidance package detects hot targets infront of itself, and guides the munition towards it."
+this.desc = "Similar to Infrared guidance but has a top-attack trajectory. This guidance package which relies on the heat of the target to guide itself. Will be unable to lock a target if it is not hot enough. Can be defeated by flares. Fire and forget."
 
 this.TTime = 0
 

--- a/lua/acf/shared/guidances/k_beamrider.lua
+++ b/lua/acf/shared/guidances/k_beamrider.lua
@@ -13,7 +13,7 @@ this.Name = ClassName
 -- Cone to retain targets within.
 this.ViewCone = 30
 
-this.desc = "This guidance package directs the missile to keep it in line with the sight as if it were riding a beam. Results in a fast traveltime."
+this.desc = "A guidance package that guides a missile to follow a line. Typically in line with the missile launcher. Though less efficient than other guidance methods it makes up for it in price. Will either follow the facing of the launching missile or any spawned optical computer entity."
 
 this.GuidanceEntity = nil
 

--- a/lua/acf/shared/guidances/l_straightrunning.lua
+++ b/lua/acf/shared/guidances/l_straightrunning.lua
@@ -13,7 +13,7 @@ this.Name = ClassName
 -- An entity with a Position wire-output
 this.InputSource = nil
 
-this.desc = "Gyroscopic torpedo. Guides the torpedo to the depth and direction of the targetpos or the direction fired."
+this.desc = "Gyroscopic torpedo. Programmed at the time of launch and cannot be adjusted afterward. If provided with a target position will try to match the depth of the target position and travel along the bearing. Otherwise the torpedo will travel in the direction it was launched maintaining the depth it was launched at."
 
 -- Disables guidance when true
 this.FirstGuidance = true
@@ -63,7 +63,9 @@ function this:GetGuidance(missile)
 		self.TPos = MPos + self.TPos * 500000
 		self.TPos = Vector(self.TPos.x,self.TPos.y,zHeight)
 
-		self.FirstGuidance = false
+		if missile.MissileActive then
+			self.FirstGuidance = false
+		end
 	end
 
 	local Difpos = (self.TPos-MPos)

--- a/lua/acf/shared/guidances/m_acoustic_spiral.lua
+++ b/lua/acf/shared/guidances/m_acoustic_spiral.lua
@@ -31,7 +31,7 @@ this.SeekDelay = 1.5 -- Re-seek drastically reduced cost so we can re-seek. Dyna
 this.MinimumDistance = 393.7	--10m
 this.MaxDistance = 150 * 39.37	--10m
 
-this.desc = "Acoustic torpedo guidance with a helical search pattern."
+this.desc = "Acoustic torpedo that will track any targets in the water within a cone. Follows a helical search pattern and will continuously search up and down to cover multiple depths. Useful for airdropped torpedoes. WARNING: Targetposition can only specify the depth to search at. This torpedo will search around the area it was first dropped."
 --Useful for airdropped torpedoes. Follows a helical pattern until it reaches its target depth. WARNING: Targetposition can only specify the depth to search at. This torpedo will search around the area it was first dropped.
 
 --Sets initial guidance info
@@ -80,7 +80,9 @@ function this:GetGuidance(missile)
 			self.TarPos = (posVec - missilePos):GetNormalized()
 		end
 
-		self.FirstGuidance = false
+		if missile.MissileActive then
+			self.FirstGuidance = false
+		end
 	end
 
 	local override = self:ApplyOverride(missile)

--- a/lua/acf/shared/guidances/m_acoustic_straight.lua
+++ b/lua/acf/shared/guidances/m_acoustic_straight.lua
@@ -31,7 +31,7 @@ this.SeekDelay = 2 -- Re-seek drastically reduced cost so we can re-seek. Dynami
 this.MinimumDistance = 393.7	--10m
 this.MaxDistance = 100 * 39.37	--10m
 
-this.desc = "Acoustic torpedo guidance."
+this.desc = "Acoustic torpedo that will track any targets in the water within a cone. This torpedo will swim in a straight line searching for a target. If provided with a target position the torpedo will try to match the depth of the target position and travel along the bearing. Otherwise the torpedo will travel in the direction it was launched maintaining the depth it was launched at."
 --Useful for airdropped torpedoes. Follows a helical pattern until it reaches its target depth. WARNING: Targetposition can only specify the depth to search at. This torpedo will search around the area it was first dropped.
 
 --Sets initial guidance info
@@ -81,7 +81,9 @@ function this:GetGuidance(missile)
 
 		self.TarPos = missilePos + self.TarPos * 500000
 		self.TarPos = Vector(self.TarPos.x,self.TarPos.y,zHeight)
-		self.FirstGuidance = false
+		if missile.MissileActive then
+			self.FirstGuidance = false
+		end
 	end
 
 	local override = self:ApplyOverride(missile)

--- a/lua/acf/shared/guidances/n_gps_terrain_avoiding.lua
+++ b/lua/acf/shared/guidances/n_gps_terrain_avoiding.lua
@@ -13,7 +13,7 @@ this.Name = ClassName
 -- An entity with a Position wire-output
 this.InputSource = nil
 
-this.desc = "Terrain following GPS guidance. This guidance package recieves a one-time position and guides to it staying as low as possible."
+this.desc = "A form of guidance that guides directly towards a target point. Programmed at the time of launch and cannot be adjusted after. Will head straight towards the target position regardless of line of sight or seeker cone. Fire and forget.\n This form of GPS Guidance is capable of avoiding terrain. And will try to fly as low as possible towards a target."
 
 -- Disables guidance when true
 this.FirstGuidance = true
@@ -58,7 +58,9 @@ function this:GetGuidance(missile)
 
 		--self.TPos = MPos + self.TPos * 500000
 
-		self.FirstGuidance = false
+		if missile.MissileActive then
+			self.FirstGuidance = false
+		end
 	end
 
 	local LastDist = self.Dist or 0

--- a/lua/acf/shared/guidances/o_command.lua
+++ b/lua/acf/shared/guidances/o_command.lua
@@ -13,7 +13,7 @@ this.Name = ClassName
 -- Cone to retain targets within.
 this.ViewCone = 30
 
-this.desc = "This guidance package reads a target-position from the launcher and guides the munition towards it. The launcher must have LOS to the missile."
+this.desc = "A form of guidance that steers a missile towards the target position of the launcher using radio commands. Requires a line of sight from the launcher to the missile to guide. ECM is capable of disrupting the guidance signal."
 
 
 

--- a/lua/acf/shared/missiles/missile_naval.lua
+++ b/lua/acf/shared/missiles/missile_naval.lua
@@ -602,8 +602,8 @@ ACE.DefineGun("Mk54 Torp", {						-- id
 	bodydiameter     = 36, -- If this ordnance has fixed fins. Add this to count the body without finds, to ensure the missile will fit properly on the rack (doesnt affect the ammo dimension)
 
 	round = {
-		rocketmdl			= "models/macc/Torpedo_MK13_Small.mdl",
-		rackmdl				= "models/macc/Torpedo_MK13_Small.mdl",
+		rocketmdl			= "models/macc/Torpedo_MK13.mdl",
+		rackmdl				= "models/macc/Torpedo_MK13.mdl",
 		firedelay			= 0.5,
 		reloadspeed			= 6.0,
 		reloaddelay			= 25.0,

--- a/lua/acf/shared/sh_ace_points_model.lua
+++ b/lua/acf/shared/sh_ace_points_model.lua
@@ -91,8 +91,16 @@ local AUTO_CLASSES = { AC = true, MG = true, RAC = true, HMG = true, GL = true, 
 local FUEL_FACTOR  = { Petrol = 1.0, Diesel = 1.2, Multifuel = 1.2, Electric = 0.8 }
 -- Guidance names omitted from this table use a 1.0 multiplier.
 local GUIDANCE = {
-	Dumb = 0.5, Straight_Running = 0.6, Radar = 1.4, Semiactive = 1.4,
-	Infrared = 1.5, Top_Attack_IR = 1.8, GPS = 0.8, GPS_TerrainAvoidant = 0.9,
+	Dumb = 0.5,
+	Straight_Running = 0.6,
+	Radar = 1.4,
+	Semiactive = 0.8,
+	Infrared = 1.2,
+	Top_Attack_IR = 1.8,
+	GPS = 0.7,
+	GPS_TerrainAvoidant = 0.8,
+	AntiRadiation = 0.6, --Cost lowered to increase viability of antiradiation missiles as a backup weapon.
+	Beam_Riding = 0.8, --Beamriding is an inferior guidance method due to inability to see in 3d and wasted energy.
 }
 
 -- Lethality once the round is inside armor: base damage plus the hole it tears

--- a/lua/entities/ace_missile/init.lua
+++ b/lua/entities/ace_missile/init.lua
@@ -162,7 +162,7 @@ function ENT:Think()
 
 	if self.WaterZHeight == 0 then
 		local WaterTr = { }
-		WaterTr.start = Pos + Vector(0,0, 50000)
+		WaterTr.start = Pos + Vector(0,0, 10000)
 		WaterTr.endpos = Pos
 		WaterTr.mask = MASK_WATER
 		local Water = util.TraceLine( WaterTr )
@@ -172,12 +172,12 @@ function ENT:Think()
 		end
 
 	elseif self.WaterZHeight ~= -1 then
-		--print(Pos.z - self.WaterZHeight)
 		if Pos.z < self.WaterZHeight and Pos.z - self.WaterZHeight > -500 and self.MissileActive and CT > (self.NextWaterSplash or 0) then
+			--print(Pos.z - self.WaterZHeight)
 			self.NextWaterSplash = CT + 0.03
 			self.WaterZHeight = self.WaterZHeight
 			local Sparks = EffectData()
-			Sparks:SetOrigin( Vector(Pos.x, Pos.y, self.WaterZHeight) )
+			Sparks:SetOrigin( Vector(Pos.x, Pos.y, self.WaterZHeight + 50) )
 			Sparks:SetScale( self.RoundWeight / 50 )
 			util.Effect( "waterripple", Sparks )
 		end

--- a/lua/entities/acf_gun/init.lua
+++ b/lua/entities/acf_gun/init.lua
@@ -131,7 +131,7 @@ do
 		Unload      = "Unload (Unloads the current shell from the gun. Leaving the gun empty.)",
 		Reload      = "Reload (Reloads the current weapon, according to the active ammo it has.)",
 		FuseTime    = "Fuse Time (Defines the required time for shell self-detonation in seconds. \nThis only work with SM, HE & HEAT rounds. \nNote that this is not really accurate.)",
-		ROFLimit    = "ROFLimit (Adjusts the Gun's Rate of Fire. \nNote that setting this to 0 WILL disable overriding! \nIf you want lower rof, use values like 0.1.)",
+		ROFLimit    = "ROFLimit (Limits the Gun's rate of fire to the specified value in Rounds Per Minute. \nUsing a number of 0 or less will disable the firerate limit.)",
 	}
 	local Outputs = {
 		Ready           = "Ready (Returns if the gun is ready to fire.)",

--- a/lua/entities/acf_rack/init.lua
+++ b/lua/entities/acf_rack/init.lua
@@ -22,11 +22,14 @@ local RackWireDescs = {
 	--Inputs
 	["Reload"]       = "Arms this rack. Its mandatory to set this since racks don't reload automatically.",
 	["TargetPos"]    = "Defines the Target position for the ordnance in this rack. This only works for Wire and laser guidances.",
+	["ActivateGuidance"] = "This input is only used to activate the missile seeker while it is still on the rails.\nUseful to see what your missile is tracking or able to see before firing.\nRegardless of input missiles will activate their guidance when fired.",
 	["Delay"]        = "Sets a specific delay to guidance control over the default one in seconds.",
 	["Detonate"]        = "Remotely detonate any currently outbound missiles.",
 
-	--Outputs
+	--Outputs 
 	["Ready"]        = "Returns if the rack is ready to fire.",
+	["AcquiredTarget"]        = "Whether the missile currently on the rails has found a target.\n Requires ActivateGuidance to be active for the missile to see on the rails.",
+	["TargetDirection"]        = "If the missile on the rails currently has a target, outputs a direction vector towards the target.\n Requires ActivateGuidance to be active for the missile to see on the rails.",
 	["CurMissile"]        = "Outputs the next position of the missile in the rack getting fired.",
 	["PositionFiredMissile"] = "Outputs the position of the missile last fired by this launcher"
 
@@ -79,10 +82,10 @@ function ENT:Initialize()
 
 	self.SelfContraption = nil
 
-	self.Inputs = WireLib.CreateSpecialInputs( self, { "Fire",	"Reload (" .. RackWireDescs["Reload"] .. ")",	"Target Pos (" .. RackWireDescs["TargetPos"] .. ")", "Activate Guidance", "Track Delay (" .. RackWireDescs["Delay"] .. ")", "Detonate Missile (" .. RackWireDescs["Detonate"] .. ")" },
+	self.Inputs = WireLib.CreateSpecialInputs( self, { "Fire",	"Reload (" .. RackWireDescs["Reload"] .. ")",	"Target Pos (" .. RackWireDescs["TargetPos"] .. ")",	"Activate Guidance (" .. RackWireDescs["ActivateGuidance"] .. ")", "Track Delay (" .. RackWireDescs["Delay"] .. ")", "Detonate Missile (" .. RackWireDescs["Detonate"] .. ")" },
 													{ "NORMAL", "NORMAL", "VECTOR", "NORMAL", "NORMAL", "NORMAL" } )
 
-	self.Outputs = WireLib.CreateSpecialOutputs( self,  { "Ready (" .. RackWireDescs["Ready"] .. ")",	"Shots Left", "AcquiredTarget", "TargetDirection", "Current Missile", "Missile Info", "CurMissile", "PositionFiredMissile" },
+	self.Outputs = WireLib.CreateSpecialOutputs( self,  { "Ready (" .. RackWireDescs["Ready"] .. ")",	"Shots Left", "AcquiredTarget (" .. RackWireDescs["AcquiredTarget"] .. ")", "TargetDirection (" .. RackWireDescs["TargetDirection"] .. ")", "Current Missile", "Missile Info", "CurMissile", "PositionFiredMissile" },
 														{ "NORMAL", "NORMAL", "NORMAL", "VECTOR", "ENTITY", "STRING", "NORMAL", "VECTOR" } )
 
 	Wire_TriggerOutput(self, "Ready", 1)


### PR DESCRIPTION
Redid descriptions of missile guidance types to make their function more apparent.

Clarified description of certain missile launcher inputs and outputs.

Specified that gun firerate limiter is in rounds per minute

Made GPS, straightrunning, and acoustic guidances unable to be programmed before firing. Preventing them from being programmed on launch.

Reduced cost of antiradiation missiles to encourage their use against radar SPAA

Beamriding cost reduced due to inferior efficiency and targeting compared to other point targeting guidance.
